### PR TITLE
Fix bug where markup was being printed on the page

### DIFF
--- a/app/assets/javascripts/render_combined_twitter_feed.js
+++ b/app/assets/javascripts/render_combined_twitter_feed.js
@@ -16,11 +16,6 @@ function renderCombinedTwitterFeed(legislators){
     data: { handles: legislatorTwitterHandles, feed_length: 13 },
     success: function(tweets) {
 
-      // Clear the feed if there are already tweets
-      if($("#feed").after("#feed h2").has("article")) {
-        $("#feed").after("#feed h2").empty()
-      }
-
       // Set the page title
       $("#feed").append("<h2 id='feed-title'>Here\'s what your legislators have been saying:</h2>")
 

--- a/app/assets/javascripts/render_individual_twitter_feed.js
+++ b/app/assets/javascripts/render_individual_twitter_feed.js
@@ -14,9 +14,7 @@ function getIndividualTwitterFeed(legislatorName, handle){
     success: function(tweets) {
 
       // Clear the feed if there are already tweets
-      if($("#feed").after("#feed h2").has("article")) {
-        $("#feed").after("#feed h2").empty()
-      }
+      $("#feed").after().empty()
 
       // Set the page title
       $("#feed").append("<h2 id='feed-title'>Here\'s what your legislators have been saying:</h2>")


### PR DESCRIPTION
close #53 

Remove condition from renderCombinedFeed
because the combined feed will always be rendered
from a fresh page-load,
and never rendered when there's already content
in the feed.

Remove condition from renderIndividualFeed:
Always empty the feed when rendering an individual feed
because the old feed will need to be removed
before the new feed is displayed
